### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-4.2 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 5.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.1 (2025-06-04)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -49,9 +48,6 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['grokcore'],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name='grokcore.formlib',
-    version='4.2.dev0',
+    version='5.0.dev0',
     author='Grok Team',
     author_email='zope-dev@zope.dev',
     url='https://github.com/zopefoundation/grokcore.formlib',

--- a/src/grokcore/__init__.py
+++ b/src/grokcore/__init__.py
@@ -1,7 +1,0 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/grokcore/formlib/__init__.py
+++ b/src/grokcore/formlib/__init__.py
@@ -13,10 +13,13 @@
 ##############################################################################
 """Grok
 """
+from grokcore.component import *
+from grokcore.security import *
+from grokcore.view import *
+
 # Import this module so that it's available as soon as you import the
 # 'grokcore.formlib' package.  Useful for tests and interpreter examples.
 import grokcore.formlib.testing
-from grokcore.component import *
 from grokcore.formlib.components import AddForm
 from grokcore.formlib.components import DisplayForm
 from grokcore.formlib.components import EditForm
@@ -26,8 +29,6 @@ from grokcore.formlib.formlib import Fields
 from grokcore.formlib.formlib import action
 # Our __init__ provides the grok API directly so using 'import grok' is enough.
 from grokcore.formlib.interfaces import IGrokcoreFormlibAPI
-from grokcore.security import *
-from grokcore.view import *
 
 
 __all__ = list(IGrokcoreFormlibAPI)

--- a/src/grokcore/formlib/components.py
+++ b/src/grokcore/formlib/components.py
@@ -19,6 +19,8 @@ import warnings
 
 import pytz
 
+from grokcore.view import PageTemplateFile
+from grokcore.view import View
 from zope.formlib import form
 from zope.interface import implementer_only
 from zope.interface.common import idatetime
@@ -26,8 +28,6 @@ from zope.publisher.publish import mapply
 
 from grokcore.formlib import formlib
 from grokcore.formlib.interfaces import IGrokForm
-from grokcore.view import PageTemplateFile
-from grokcore.view import View
 
 
 default_form_template = PageTemplateFile(os.path.join(

--- a/src/grokcore/formlib/formlib.py
+++ b/src/grokcore/formlib/formlib.py
@@ -18,11 +18,10 @@ import zope.event
 import zope.formlib.form
 import zope.interface
 import zope.lifecycleevent
+from grokcore.content import ObjectEditedEvent
 from zope.formlib.interfaces import IInputWidget
 from zope.interface.interfaces import IInterface
 from zope.schema.interfaces import IField
-
-from grokcore.content import ObjectEditedEvent
 
 
 class action(zope.formlib.form.action):

--- a/src/grokcore/formlib/interfaces.py
+++ b/src/grokcore/formlib/interfaces.py
@@ -13,12 +13,11 @@
 ##############################################################################
 """Grok interfaces
 """
+from grokcore.view.interfaces import IGrokView
 from zope.formlib.interfaces import reConstraint
 from zope.interface import Attribute
 from zope.interface import Interface
 from zope.schema import ASCII
-
-from grokcore.view.interfaces import IGrokView
 
 
 class IGrokForm(IGrokView):

--- a/src/grokcore/formlib/meta.py
+++ b/src/grokcore/formlib/meta.py
@@ -13,10 +13,10 @@
 ##############################################################################
 """Grokkers for the various components."""
 
+import grokcore.component
 import martian
 from martian.error import GrokError
 
-import grokcore.component
 from grokcore.formlib import components
 from grokcore.formlib import formlib
 

--- a/src/grokcore/formlib/testing.py
+++ b/src/grokcore/formlib/testing.py
@@ -13,15 +13,14 @@
 ##############################################################################
 """Grok test helpers
 """
-import martian
-from martian.error import GrokError
-from zope.configuration.config import ConfigurationMachine
-
 import grokcore.security
+import martian
 from grokcore.component import Context
 from grokcore.component import zcml
 from grokcore.security.util import protect_getattr
 from grokcore.security.util import protect_setattr
+from martian.error import GrokError
+from zope.configuration.config import ConfigurationMachine
 
 
 # Below is a simple grokker + directives that allow you to protect

--- a/src/grokcore/formlib/tests/__init__.py
+++ b/src/grokcore/formlib/tests/__init__.py
@@ -13,10 +13,13 @@
 ##############################################################################
 """Grok
 """
+from grokcore.component import *
+from grokcore.security import *
+from grokcore.view import *
+
 # Import this module so that it's available as soon as you import the
 # 'grokcore.formlib' package.  Useful for tests and interpreter examples.
 import grokcore.formlib.testing
-from grokcore.component import *
 from grokcore.formlib.components import AddForm
 from grokcore.formlib.components import DisplayForm
 from grokcore.formlib.components import EditForm
@@ -26,8 +29,6 @@ from grokcore.formlib.formlib import Fields
 from grokcore.formlib.formlib import action
 # Our __init__ provides the grok API directly so using 'import grok' is enough.
 from grokcore.formlib.interfaces import IGrokcoreFormlibAPI
-from grokcore.security import *
-from grokcore.view import *
 
 
 __all__ = list(IGrokcoreFormlibAPI)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
